### PR TITLE
Fix: Shaded Event 7 decreases trackable ARVN resources

### DIFF
--- a/src/main/scala/fitl/cards/Card_007.scala
+++ b/src/main/scala/fitl/cards/Card_007.scala
@@ -73,7 +73,8 @@ object Card_007 extends EventCard(7, "ADSID",
     if (game.trail < TrailMax) {
       val num = if (game.trail < 2) 2 - game.trail else 1
       improveTrail(num)
-      decreaseResources(ARVN, 9)
     }
+    if (game.trackResources(ARVN))
+      decreaseResources(ARVN, 9)
   }
 }


### PR DESCRIPTION
Hi,
Shaded event of card 7 was not decreasing ARVN resources by 9 when US is human player. I hope that my code is correct.