### PR TITLE
Fix: NVA infiltrate special activity will replace just enough NVA Guerrillas with available NVA Troops

### DIFF
--- a/src/main/scala/fitl/Bot.scala
+++ b/src/main/scala/fitl/Bot.scala
@@ -6226,11 +6226,12 @@ object Bot {
                                 game.availablePieces.has(NVATroops)   &&
                                 troopCandidates.nonEmpty
           if (canPlace) {
-            val sp        = pickSpacePlaceTroops(troopCandidates)
-            val numGs     = (sp.pieces.totalOf(NVAGuerrillas) - 2) max 0
-            val numTroops = (game.trail + sp.pieces.totalOf(NVABases) + numGs) min game.availablePieces.totalOf(NVATroops)
-            val toRemove  = selectFriendlyRemoval(sp.pieces.only(NVAGuerrillas), numGs)
-            val toPlace   = Pieces(nvaTroops = numTroops)
+            val sp          = pickSpacePlaceTroops(troopCandidates)
+            val numGs       = (sp.pieces.totalOf(NVAGuerrillas) - 2) max 0
+            val numTroops   = (game.trail + sp.pieces.totalOf(NVABases) + numGs) min game.availablePieces.totalOf(NVATroops)
+            val numActualGs = (numTroops - game.trail - sp.pieces.totalOf(NVABases)) max 0
+            val toRemove    = selectFriendlyRemoval(sp.pieces.only(NVAGuerrillas), numActualGs)
+            val toPlace     = Pieces(nvaTroops = numTroops)
             if (!params.event && infiltrateSpaces.isEmpty)
               logSAChoice(NVA, Infiltrate, notes)
 


### PR DESCRIPTION
There is a rare case when the infiltration space contains more NVA Guerrillas than available NVA Troops - presented NVA Bases - Trail. Current execution of Infiltrate special activity would remove more Guerrillas than are needed to replace them with NVA Troops.

Example:
Space contains 2 NVA Bases and 10 Guerrillas.
The value of Trail is 2.
There are 5 available NVA Troops.
Current execution of infiltrate activity would remove 8 Guerrillas and add only 5 (available) Troops.

Proposed fix would remove only 1 Guerrilla for 1 additional Troop as stated in 4.4.1 rule.