### PR TITLE
Fix: Card #94 is picking provinces with tunneled bases when placing Tunnel marker.

### DIFF
--- a/src/main/scala/fitl/cards/Card_094.scala
+++ b/src/main/scala/fitl/cards/Card_094.scala
@@ -62,7 +62,7 @@ object Card_094 extends EventCard(94, "Tunnel Rats",
 
   val provinceWithNVANonTunnel = (sp: Space) =>
     sp.isProvince &&
-    sp.pieces.has(NVABases)
+    sp.pieces.has(NVABase)
 
   val provinceWithNonTunnel = (sp: Space) =>
     sp.isProvince &&


### PR DESCRIPTION
There is an error in card #94. When selecting a province with an NVA base to place a tunnel marker, the card is also selecting provinces that contain only tunneled bases.

The current code uses NVABases (plural) to determine candidate provinces. However, NVABases includes both NVABase and NVATunnel. The code has been corrected to use only NVABase (singular) when determining candidate provinces.

Example: I have attached a game log. The next player is NP NVA, who is about to execute the card event, which results in an assertion failure.

[5 ARVN Full.zip](https://github.com/user-attachments/files/20879049/5.ARVN.Full.zip)
