### PR TITLE
Fixed app freezing when NP US cannot move any Troops to Saigon while performing Patrol Operation

### DIFF
--- a/src/main/scala/fitl/Bot.scala
+++ b/src/main/scala/fitl/Bot.scala
@@ -3400,7 +3400,7 @@ object Bot {
         // Select a LoC Patrol destination candidate
         // ARVN Patrol never needs an activation roll
         val saigonCandidate = (_: Boolean, _: Boolean, prohibited: Set[String]) => {
-          if (!game.getSpace(Saigon).coinControlled) Some(Saigon) else None
+          if (!game.getSpace(Saigon).coinControlled && !prohibited.contains(Saigon)) Some(Saigon) else None
         }
 
         val locPatrolCandidate = (_: Boolean, _: Boolean, prohibited: Set[String]) => {


### PR DESCRIPTION
When the NP US selects the Patrol operation (i.e. F card), it first chooses Saigon if it’s not COIN-controlled. That is the case in the example I’m sending you. It can’t find a suitable origin for Troops movement and app ends up in an infinite loop.

I’ve corrected that.
[6 NVA Full.zip](https://github.com/user-attachments/files/20969102/6.NVA.Full.zip)
