### PR TITLE
Failed coup card should not change the state of RVN Leader

### DIFF
--- a/src/main/scala/fitl/FireInTheLake.scala
+++ b/src/main/scala/fitl/FireInTheLake.scala
@@ -3221,7 +3221,7 @@ object FireInTheLake {
         log(s"\nPlace $coupCard beneath the other cards in the RVN Leader Box", Color.Event)
         // Place above RVN_Leader_DuongVanMinh which is printed on the map
         val newLeaders = game.rvnLeaders.init:::List(newLeader, game.rvnLeaders.last)
-        game = game.copy(rvnLeaders = newLeaders, rvnLeaderFlipped = false)
+        game = game.copy(rvnLeaders = newLeaders)
       }
       else {
         log(s"\nPlace $coupCard in the RVN Leader Box on top of the stack", Color.Event)


### PR DESCRIPTION
Situation: The RVN Leader is flipped face down, and a Failed Coup card is resolved.
Error: RVN Leader is flipped face up.

There is no instruction in the rules or on the Coup card to flip the RVN Leader face up again. It occurred in the attached game between saves 034 and 035.
[ARVN2.ZIP](https://github.com/user-attachments/files/27118255/ARVN2.ZIP)
