### PR TITLE
Fix: LOC spaces have been filtered out from the provided list of spaces for the Sweep operation.

### DIFF
--- a/src/main/scala/fitl/Human.scala
+++ b/src/main/scala/fitl/Human.scala
@@ -2884,8 +2884,8 @@ object Human {
       AirLift::AirStrike::Nil
     else
       Transport::Raid::Nil
-    var sweepSpaces     = params.sweep.explicitSpaces
-    var resolvedSpaces   = Set.empty[String]
+    var sweepSpaces     = params.sweep.explicitSpaces.filterNot(game.getSpace(_).isLoC)
+    var resolvedSpaces  = Set.empty[String]
     var cobrasSpaces    = Set.empty[String]
     val alreadyMoved    = new MovingGroups()
     val platoonsShaded  = faction == US && !params.limOpOnly && capabilityInPlay(CombActionPlatoons_Shaded)


### PR DESCRIPTION
There is a case with card #117 that leads to executing a Sweep operation in a LoC location (which is not allowed by the rules).

How can this situation be reproduced?
Take the attached game and proceed with:
```
perform
1) Event
1) Unshaded
Quang Tri
6) LOC Hue -- Khe Sanh
Quang Tri
3
3) Finished moving troops

```
The application will activate (sweep) Guerilla in LOC Hue -- Khe Sanh, and that is an error.

There may be other Event cards affected by this bug, so I fixed the issue directly in the executeSweep() function.

[ARVN3.ZIP](https://github.com/user-attachments/files/27237043/ARVN3.ZIP)
